### PR TITLE
推論したlabel名が反転していたのを修正

### DIFF
--- a/function/infer.py
+++ b/function/infer.py
@@ -17,9 +17,9 @@ class Model:
     def __init__(self, model_type, model_name, labels, providers):
         """
         モデルの読み込み、基礎設定を行う
-        :param model_type : 使用するモデルのバージョン (Yolo v7 or Yolo nas)
+        :param model_type : 使用するモデルのバージョン (Yolo v7 or Yolo NAS)
         :param model_name : 使用するモデルの名前 (sugarcane or pineapple)
-        :param labels     : ラベルの名前を格納したリスト
+        :param labels     : ラベルの名前を格納したリスト ['sugarcane'('pineapple'), 'weed']
         :param providers  : onnxでモデルを読み込んだ時のプロバイダー ['CUDAExecutionProvider', 'CPUExecutionProvider']
         """
     
@@ -30,7 +30,7 @@ class Model:
     
         # 選択されたモデルのバージョンをチェック
         if model_type == "Yolo v7":
-            print(f"use YOLO v7 model. model name: {self.model_name}")
+            print(f"Use YOLO v7 model. model name: {self.model_name}")
 
             # モデルの読み込み
             self.model = ort.InferenceSession(f"./model/{self.model_name}_v7.onnx", providers=providers)
@@ -38,9 +38,12 @@ class Model:
             self.outname = [self.model.get_outputs()[0].name]
             self.inname = [i.name for i in self.model.get_inputs()]
 
-        # elif model_type == "Yolo nas":
-        #   self.model = ort.InferenceSession(f"./model/{model_name}-yolonas.onnx", providers=providers)
-        #   self.label_names = labels.append(self.model_name)
+        elif model_type == "Yolo NAS":
+            print(f"Use YOLO NAS model. model name: {self.model_name}")
+            self.model = ort.InferenceSession(f"./model/{model_name}_nas.onnx", providers=providers)
+
+            self.outname = [self.model.get_outputs()[0].name]
+            self.inname = [i.name for i in self.model.get_inputs()]
 
         # ランダムでバウンディングボックスの色を決める
         self.colors = {name: [random.randint(0, 255) for _ in range(3)] for i, name in enumerate(self.labels)}

--- a/function/infer.py
+++ b/function/infer.py
@@ -38,12 +38,12 @@ class Model:
             self.outname = [self.model.get_outputs()[0].name]
             self.inname = [i.name for i in self.model.get_inputs()]
 
-        elif model_type == "Yolo NAS":
-            print(f"Use YOLO NAS model. model name: {self.model_name}")
-            self.model = ort.InferenceSession(f"./model/{model_name}_nas.onnx", providers=providers)
+        # elif model_type == "Yolo NAS":
+        #     print(f"Use YOLO NAS model. model name: {self.model_name}")
+        #     self.model = ort.InferenceSession(f"./model/{model_name}_nas.onnx", providers=providers)
 
-            self.outname = [self.model.get_outputs()[0].name]
-            self.inname = [i.name for i in self.model.get_inputs()]
+        #     self.outname = [self.model.get_outputs()[0].name]
+        #     self.inname = [i.name for i in self.model.get_inputs()]
 
         # ランダムでバウンディングボックスの色を決める
         self.colors = {name: [random.randint(0, 255) for _ in range(3)] for i, name in enumerate(self.labels)}

--- a/image_recognition.py
+++ b/image_recognition.py
@@ -28,7 +28,7 @@ class ImageRecognition(customtkinter.CTkFrame):
         self.model = Model(
             model_type=model_type,
             model_name=model_name,
-            labels=["weed", model_name], # ラベル名の順序が異なっていたらこの部分の位置を逆にする
+            labels=[model_name, "weed"],  # ここでラベルを設定
             providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
         )
 


### PR DESCRIPTION
## 概要

推論時に表示されるラベルの名前が反転していたので、それを修正


## 変更内容

- `['weed', model_name]` を `[model_name, 'weed']` に変更

## 関連Issue, PR

- Close #39 
<!--
関連するIssue番号, PR番号を箇条書きで記載してください。
番号の前に、明示的に"Close"を書くと、マージした際に自動的にIssueが閉じられます。
関連Issueが存在しない場合は、記述しなくて大丈夫です。

（例）
- #0          // PRにIssuesや別のPRを紐づける
- Close #1    // Issueを自動的にクローズ
-->


## その他
<!--
その他、レビュアーに伝えたいことなどあれば記述 (Option)
-->
