### PR TITLE
推論時のBBOXと文字のサイズを小さくする

### DIFF
--- a/function/draw.py
+++ b/function/draw.py
@@ -25,6 +25,6 @@ def draw(
     label_name_with_score = label_name + " " + str(score)
     cv2.rectangle(frame, box[:2], box[2:], color, 3)
     cv2.putText(
-        frame, label_name_with_score, (box[0], box[1] - 2), cv2.FONT_HERSHEY_SIMPLEX, 1.2, [225, 255, 255], thickness=2
+        frame, label_name_with_score, (box[0], box[1] - 2), cv2.FONT_HERSHEY_SIMPLEX, 0.85, [225, 255, 255], thickness=2
     )
     return frame

--- a/function/draw.py
+++ b/function/draw.py
@@ -23,7 +23,7 @@ def draw(
 
     color = colors[label_name]
     label_name_with_score = label_name + " " + str(score)
-    cv2.rectangle(frame, box[:2], box[2:], color, 5)
+    cv2.rectangle(frame, box[:2], box[2:], color, 3)
     cv2.putText(
         frame, label_name_with_score, (box[0], box[1] - 2), cv2.FONT_HERSHEY_SIMPLEX, 1.2, [225, 255, 255], thickness=2
     )


### PR DESCRIPTION
## 概要

今までのサイズだと、思ってたより大きかったので小さくした


## 変更内容
- bboxの大きさを5 -> 3に
- 文字サイズを 1.2 -> 0.85に

## 関連Issue, PR
<!--
関連するIssue番号, PR番号を箇条書きで記載してください。
番号の前に、明示的に"Close"を書くと、マージした際に自動的にIssueが閉じられます。
関連Issueが存在しない場合は、記述しなくて大丈夫です。

（例）
- #0          // PRにIssuesや別のPRを紐づける
- Close #1    // Issueを自動的にクローズ
-->


## その他

### before

![image](https://github.com/user-attachments/assets/6f26dbba-0811-43e9-8b08-cefab8c50017)

### after

![image](https://github.com/user-attachments/assets/72900aec-1b20-464a-a51c-c70cf1677362)

