### PR TITLE
平均fpsや推論開始の合図をprintする

### DIFF
--- a/image_recognition.py
+++ b/image_recognition.py
@@ -145,9 +145,9 @@ class ImageRecognition(customtkinter.CTkFrame):
     def print_results(self) -> None:
         if self.infer_fps:
             print()
-            print('+' * 50)
-            print('Infer FPS')
-            print('Max FPS:', max(self.infer_fps))
-            print('Mean FPS:', sum(self.infer_fps) / len(self.infer_fps))
-            print('Min FPS:', min(self.infer_fps))
-            print('+' * 50)
+            print("+" * 50)
+            print("Infer FPS")
+            print("Max FPS:", max(self.infer_fps))
+            print("Mean FPS:", sum(self.infer_fps) / len(self.infer_fps))
+            print("Min FPS:", min(self.infer_fps))
+            print("+" * 50)

--- a/image_recognition.py
+++ b/image_recognition.py
@@ -41,7 +41,7 @@ class ImageRecognition(customtkinter.CTkFrame):
         self.is_test = is_test
         self.ser = ser
 
-        self.infer_fps = []
+        self.infer_fps: list[float] = []
 
         window_width = self.winfo_width()
         window_height = self.winfo_height()

--- a/image_recognition.py
+++ b/image_recognition.py
@@ -87,6 +87,13 @@ class ImageRecognition(customtkinter.CTkFrame):
         if not self.is_test:
             self.save_video.write(frame)
 
+        # 推論開始の合図
+        if not self.infer_fps:
+            print()
+            print("** Start inference **")
+            print("Please wait a moment...")
+            print()
+
         infer_frame, fps = self.model.infer(self.is_serial, self.ser, frame)  # type: ignore
         self.infer_fps.append(fps)
 

--- a/image_recognition.py
+++ b/image_recognition.py
@@ -41,6 +41,8 @@ class ImageRecognition(customtkinter.CTkFrame):
         self.is_test = is_test
         self.ser = ser
 
+        self.infer_fps = []
+
         window_width = self.winfo_width()
         window_height = self.winfo_height()
 
@@ -86,6 +88,7 @@ class ImageRecognition(customtkinter.CTkFrame):
             self.save_video.write(frame)
 
         infer_frame, fps = self.model.infer(self.is_serial, self.ser, frame)  # type: ignore
+        self.infer_fps.append(fps)
 
         if not self.is_test:
             self.save_infer_video.write(infer_frame)
@@ -130,3 +133,14 @@ class ImageRecognition(customtkinter.CTkFrame):
         if self.is_serial:
             close_serial_port(self.ser)
         super().destroy()
+        self.print_results()
+
+    def print_results(self) -> None:
+        if self.infer_fps:
+            print()
+            print('+' * 50)
+            print('Infer FPS')
+            print('Max FPS:', max(self.infer_fps))
+            print('Mean FPS:', sum(self.infer_fps) / len(self.infer_fps))
+            print('Min FPS:', min(self.infer_fps))
+            print('+' * 50)


### PR DESCRIPTION
## 概要

表題ママ


## 変更内容
- 推論時の平均fpsのログ出力
- スタートボタンを押したときに、ちゃんとの推論開始されてるかの合図を追加


## 関連Issue, PR
<!--
関連するIssue番号, PR番号を箇条書きで記載してください。
番号の前に、明示的に"Close"を書くと、マージした際に自動的にIssueが閉じられます。
関連Issueが存在しない場合は、記述しなくて大丈夫です。

（例）
- #0          // PRにIssuesや別のPRを紐づける
- Close #1    // Issueを自動的にクローズ
-->


## その他
<!--
その他、レビュアーに伝えたいことなどあれば記述 (Option)
-->
