### PR TITLE
戻るボタンを押して再度再開する際、モデルが上手くロードされない問題を解決

### DIFF
--- a/frames.py
+++ b/frames.py
@@ -1,7 +1,7 @@
 from glob import glob
 import os
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Tuple
 
 import customtkinter
 
@@ -117,6 +117,21 @@ class ModelSelectionFrame(customtkinter.CTkFrame):
 
         self.optionmenu_var = customtkinter.StringVar()
 
+        self.models_name, self.models = self.get_models(crop, inference_model)
+
+        self.optionmenu_var = customtkinter.StringVar(value=self.models_name[0])
+
+        self.optionmenu = customtkinter.CTkOptionMenu(
+            self, values=self.models_name, command=self.optionmenu_callback, variable=self.optionmenu_var
+        )
+
+        self.optionmenu.grid(row=0, column=0, padx=10, pady=10)
+
+    def optionmenu_callback(self, choice):
+        print("optionmenu dropdown clicked:", choice)
+
+    def get_models(self, crop: CropType, inference_model: ModelType) -> Tuple[list[str], dict[str, str]]:
+        """モデルを取得"""
         models_root_path = f"models/{inference_model.lower()}-models/{crop}"
 
         if not os.path.exists(models_root_path):
@@ -134,19 +149,9 @@ class ModelSelectionFrame(customtkinter.CTkFrame):
             raise FileNotFoundError(message)
 
         models_name = [Path(model_path).stem for model_path in models_path]
+        models = {model_name: model_path for model_name, model_path in zip(models_name, models_path, strict=True)}
 
-        self.models = {model_name: model_path for model_name, model_path in zip(models_name, models_path, strict=True)}
-
-        self.optionmenu_var = customtkinter.StringVar(value=models_name[0])
-
-        optionmenu = customtkinter.CTkOptionMenu(
-            self, values=models_name, command=self.optionmenu_callback, variable=self.optionmenu_var
-        )
-
-        optionmenu.grid(row=0, column=0, padx=10, pady=10)
-
-    def optionmenu_callback(self, choice):
-        print("optionmenu dropdown clicked:", choice)
+        return models_name, models
 
     def get_model_name(self) -> str:
         return self.optionmenu_var.get()
@@ -157,3 +162,8 @@ class ModelSelectionFrame(customtkinter.CTkFrame):
 
     def set_model_path(self, value: str) -> None:
         self.optionmenu_var.set(value)
+
+    def set_model_selection(self, crop: CropType, model: ModelType) -> None:
+        """モデル選択"""
+        self.models_name, self.models = self.get_models(crop, model)
+        self.optionmenu.configure(values=self.models_name)

--- a/setup_view.py
+++ b/setup_view.py
@@ -156,6 +156,7 @@ class Setup(customtkinter.CTk):
         self.inference_model_frame.set_rbtn_value(self.inference_model_value)
         self.option_frame.set_is_serial(self.is_serial)
         self.option_frame.set_is_test(self.is_test)
+        self.model_selection_frame.set_model_selection(self.crops_value, self.inference_model_value)
         self.model_selection_frame.set_model_path(self.model_name)
 
 


### PR DESCRIPTION
## 概要
表題ママ

前に選択したモデルがYOLOv7以外だと、self.modelsの中身が更新されておらず、エラーが出る

## 変更内容
- 新たなメソッドを作り、外部からmodelsとmodel_nameを変更できるようにした
  - その際、optionmenuのvaluesも一緒に更新するようにする

## 関連Issue, PR
<!--
関連するIssue番号, PR番号を箇条書きで記載してください。
番号の前に、明示的に"Close"を書くと、マージした際に自動的にIssueが閉じられます。
関連Issueが存在しない場合は、記述しなくて大丈夫です。

（例）
- #0          // PRにIssuesや別のPRを紐づける
- Close #1    // Issueを自動的にクローズ
-->


## その他
<!--
その他、レビュアーに伝えたいことなどあれば記述 (Option)
-->
